### PR TITLE
Renaming of functions and parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ use Comes\SimpleAuthenticator\SimpleAuthenticator;
 
 $secret = 'YOUR_SECRET_KEY';
 $authenticator = new SimpleAuthenticator($secret);
-$otp = $authenticator->generateOTP();
+$oneTimePassword = $authenticator->generate();
 ```
 ## Laravel Integration
 

--- a/src/Commands/SimpleAuthenticatorCommand.php
+++ b/src/Commands/SimpleAuthenticatorCommand.php
@@ -30,7 +30,7 @@ class SimpleAuthenticatorCommand extends Command
 
         // generate otp
         try {
-            $otp = $authenticator->generateOTP($secret);
+            $oneTimePassword = $authenticator->generate($secret);
         } catch (\Exception $e) {
             $this->error('Error generating OTP');
 
@@ -38,8 +38,8 @@ class SimpleAuthenticatorCommand extends Command
         }
 
         // return otp to console
-        $this->output->writeln("<info>Your OTP is:</info> {$otp->getOTP()}");
-        $this->output->writeln("<info>Valid until:</info> {$otp->getValidUntil()->toDateTimeString()}");
+        $this->output->writeln("<info>Your OTP is:</info> {$oneTimePassword->getOneTimePassword()}");
+        $this->output->writeln("<info>Valid until:</info> {$oneTimePassword->getValidUntil()->toDateTimeString()}");
         // output current time
         $this->output->writeln('<info>Current time:</info> '.Carbon::now()->toDateTimeString());
 

--- a/src/OneTimePassword.php
+++ b/src/OneTimePassword.php
@@ -8,7 +8,7 @@ use Carbon\CarbonInterval;
 final class OneTimePassword
 {
     public function __construct(
-        private readonly string $otp,
+        private readonly string $oneTimePassword,
         private readonly CarbonImmutable $validUntil,
         private readonly CarbonInterval $validityTimespan
     ) {
@@ -17,7 +17,7 @@ final class OneTimePassword
 
     public function getOneTimePassword(): string
     {
-        return $this->otp;
+        return $this->oneTimePassword;
     }
 
     public function getValidUntil(): CarbonImmutable

--- a/src/OneTimePassword.php
+++ b/src/OneTimePassword.php
@@ -7,12 +7,15 @@ use Carbon\CarbonInterval;
 
 final class OneTimePassword
 {
-    public function __construct(private readonly string $otp, private readonly CarbonImmutable $validUntil, private readonly CarbonInterval $validityTimespan)
-    {
+    public function __construct(
+        private readonly string $otp,
+        private readonly CarbonImmutable $validUntil,
+        private readonly CarbonInterval $validityTimespan
+    ) {
         //
     }
 
-    public function getOTP(): string
+    public function getOneTimePassword(): string
     {
         return $this->otp;
     }

--- a/src/OneTimePassword.php
+++ b/src/OneTimePassword.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Comes\SimpleAuthenticator\DTO;
+namespace Comes\SimpleAuthenticator;
 
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;

--- a/src/SimpleAuthenticator.php
+++ b/src/SimpleAuthenticator.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Carbon;
 
 class SimpleAuthenticator
 {
-    public function generateOTP(string $secret, ?CarbonInterval $validityTimespan = null): OneTimePassword
+    public function generate(string $secret, ?CarbonInterval $validityTimespan = null): OneTimePassword
     {
         $validityTimespan ??= CarbonInterval::seconds(30);
 
@@ -28,7 +28,7 @@ class SimpleAuthenticator
         $offset = ord(substr($hash, -1)) & 0x0F;
 
         // Calculate OTP
-        $otp = (
+        $oneTimePassword = (
             (ord($hash[$offset + 0]) & 0x7F) << 24 |
             (ord($hash[$offset + 1]) & 0xFF) << 16 |
             (ord($hash[$offset + 2]) & 0xFF) << 8 |
@@ -36,11 +36,11 @@ class SimpleAuthenticator
         ) % pow(10, 6);
 
         // Zero-padding if necessary
-        $otp = str_pad($otp, 6, '0', STR_PAD_LEFT);
+        $oneTimePassword = str_pad($oneTimePassword, 6, '0', STR_PAD_LEFT);
 
         $validUntil = CarbonImmutable::createFromTimestamp(($time + 1) * $validityTimespan->totalSeconds);
 
-        return new OneTimePassword($otp, $validUntil, $validityTimespan);
+        return new OneTimePassword($oneTimePassword, $validUntil, $validityTimespan);
     }
 
     private function base32Decode($base32): string

--- a/src/SimpleAuthenticator.php
+++ b/src/SimpleAuthenticator.php
@@ -4,7 +4,6 @@ namespace Comes\SimpleAuthenticator;
 
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
-use Comes\SimpleAuthenticator\DTO\OneTimePassword;
 use Illuminate\Support\Carbon;
 
 class SimpleAuthenticator

--- a/tests/OneTimePasswordTest.php
+++ b/tests/OneTimePasswordTest.php
@@ -5,14 +5,14 @@ use Carbon\CarbonInterval;
 use Comes\SimpleAuthenticator\OneTimePassword;
 
 it('can create a OneTimePassword DTO', function () {
-    $otp = '123456';
+    $oneTimePassword = '123456';
     $validUntil = CarbonImmutable::now()->addMinutes(5);
     $validityTimespan = CarbonInterval::seconds(30);
 
-    $dto = new OneTimePassword($otp, $validUntil, $validityTimespan);
+    $dto = new OneTimePassword($oneTimePassword, $validUntil, $validityTimespan);
 
     expect($dto)->toBeInstanceOf(OneTimePassword::class);
-    expect($dto->getOTP())->toBe($otp);
+    expect($dto->getOneTimePassword())->toBe($oneTimePassword);
     expect($dto->getValidUntil())->toBeInstanceOf(CarbonImmutable::class);
     expect($dto->getValidUntil())->toBe($validUntil);
     expect($dto->getValidityTimespan())->toBe($validityTimespan);

--- a/tests/OneTimePasswordTest.php
+++ b/tests/OneTimePasswordTest.php
@@ -2,7 +2,7 @@
 
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
-use Comes\SimpleAuthenticator\DTO\OneTimePassword;
+use Comes\SimpleAuthenticator\OneTimePassword;
 
 it('can create a OneTimePassword DTO', function () {
     $otp = '123456';

--- a/tests/SimpleAuthenticatorTest.php
+++ b/tests/SimpleAuthenticatorTest.php
@@ -14,10 +14,10 @@ it('generates OTP correctly', function () {
     $authenticator = new SimpleAuthenticator;
 
     $expectedOTP = '900235';
-    $dto = $authenticator->generateOTP($secret);
+    $dto = $authenticator->generate($secret);
 
     expect($dto)->toBeInstanceOf(OneTimePassword::class);
-    expect($dto->getOTP())->toBe($expectedOTP);
+    expect($dto->getOneTimePassword())->toBe($expectedOTP);
 });
 
 it('throws exception for invalid base32 character', function () {
@@ -25,6 +25,6 @@ it('throws exception for invalid base32 character', function () {
     $authenticator = new SimpleAuthenticator;
 
     expect(function () use ($authenticator, $secret) {
-        $authenticator->generateOTP($secret);
+        $authenticator->generate($secret);
     })->toThrow(\RuntimeException::class, 'Invalid base32 character');
 });

--- a/tests/SimpleAuthenticatorTest.php
+++ b/tests/SimpleAuthenticatorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Comes\SimpleAuthenticator\DTO\OneTimePassword;
+use Comes\SimpleAuthenticator\OneTimePassword;
 use Comes\SimpleAuthenticator\SimpleAuthenticator;
 use Illuminate\Support\Carbon;
 


### PR DESCRIPTION
This PR renames some functions and parameters mainly to have more expressive naming and not using abbreviations like "otp" for _One Time Password_