### PR TITLE
Implement a custom InvalidSecretException

### DIFF
--- a/src/Commands/SimpleAuthenticatorCommand.php
+++ b/src/Commands/SimpleAuthenticatorCommand.php
@@ -2,6 +2,7 @@
 
 namespace Comes\SimpleAuthenticator\Commands;
 
+use Comes\SimpleAuthenticator\InvalidSecretException;
 use Comes\SimpleAuthenticator\SimpleAuthenticator;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
@@ -31,8 +32,8 @@ class SimpleAuthenticatorCommand extends Command
         // generate otp
         try {
             $oneTimePassword = $authenticator->generate($secret);
-        } catch (\Exception $e) {
-            $this->error('Failed to generate one time password');
+        } catch (InvalidSecretException $e) {
+            $this->error('Invalid secret for one-time password generation');
 
             return self::FAILURE;
         }

--- a/src/InvalidSecretException.php
+++ b/src/InvalidSecretException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Comes\SimpleAuthenticator;
+
+use UnexpectedValueException;
+
+class InvalidSecretException extends UnexpectedValueException
+{
+
+}

--- a/src/InvalidSecretException.php
+++ b/src/InvalidSecretException.php
@@ -6,5 +6,4 @@ use UnexpectedValueException;
 
 class InvalidSecretException extends UnexpectedValueException
 {
-
 }

--- a/src/SimpleAuthenticator.php
+++ b/src/SimpleAuthenticator.php
@@ -13,6 +13,7 @@ class SimpleAuthenticator
      * Note that this class uses the Unix times epoc.
      *
      * @link https://en.wikipedia.org/wiki/Time-based_one-time_password
+     * @throws InvalidSecretException
      */
     public function generate(string $secret, ?CarbonInterval $validityTimespan = null): OneTimePassword
     {
@@ -50,7 +51,7 @@ class SimpleAuthenticator
         return str_pad($oneTimePassword, 6, '0', STR_PAD_LEFT);
     }
 
-    private function base32Decode($base32): string
+    private function base32Decode(string $string): string
     {
         $base32chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
         $base32charsFlipped = array_flip(str_split($base32chars));
@@ -64,11 +65,11 @@ class SimpleAuthenticator
         // Reverse the base32 encoding and convert the secret key back to its original binary form.
         // Accumulate bits into a buffer and convert them into bytes, appending them to the output.
         // Throw an exception if an invalid base32 character is encountered.
-        while ($i < strlen($base32)) {
-            $char = strtoupper($base32[$i]);
+        while ($i < strlen($string)) {
+            $char = strtoupper($string[$i]);
 
             if (! isset($base32charsFlipped[$char])) {
-                throw new \RuntimeException('Invalid base32 character: '.$char);
+                throw new InvalidSecretException('Invalid base32 character: '.$char);
             }
 
             $buffer <<= 5;

--- a/src/SimpleAuthenticator.php
+++ b/src/SimpleAuthenticator.php
@@ -13,6 +13,7 @@ class SimpleAuthenticator
      * Note that this class uses the Unix times epoc.
      *
      * @link https://en.wikipedia.org/wiki/Time-based_one-time_password
+     *
      * @throws InvalidSecretException
      */
     public function generate(string $secret, ?CarbonInterval $validityTimespan = null): OneTimePassword

--- a/tests/SimpleAuthenticatorCommandTest.php
+++ b/tests/SimpleAuthenticatorCommandTest.php
@@ -34,13 +34,13 @@ it('handles secret not found in config file', function () {
         ->expectsConfirmation('Calculate anyway?', 'no');
 })->group('command');
 
-it('handles exception during OTP generation', function () {
+it('handles exception during one time password generation', function () {
     // Set up the test data
-    $app = 'test_app';
+    $app = 'invalid_app';
 
     // Execute the command
     $this->artisan('otp', ['app' => $app])
         ->expectsConfirmation('Calculate anyway?', 'yes')
-        ->expectsOutput('Failed to generate one time password')
+        ->expectsOutput('Invalid secret for one-time password generation')
         ->assertExitCode(1);
 })->group('command');

--- a/tests/SimpleAuthenticatorTest.php
+++ b/tests/SimpleAuthenticatorTest.php
@@ -26,5 +26,5 @@ it('throws exception for invalid base32 character', function () {
 
     expect(function () use ($authenticator, $secret) {
         $authenticator->generate($secret);
-    })->toThrow(\RuntimeException::class, 'Invalid base32 character');
+    })->toThrow(\Comes\SimpleAuthenticator\InvalidSecretException::class, 'Invalid base32 character');
 });


### PR DESCRIPTION
Implement a custom `InvalidSecretException` which makes it possible to solely catch this exception while letting other (unexpected) exceptions bubble up to the exception handler